### PR TITLE
feat: Call OPCUA methods using device profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,20 @@
 
 This repository is a Go-based EdgeX Foundry Device Service which uses OPC-UA protocol to interact with the devices or IoT objects.
 
-## Feature
+## Features
 
-1. Subscribe data from OPCUA endpoint (TBD)
-2. Execute read command
-3. Execute write command
-4. Execute method (using Read command of device SDK)
+1. Execute read command
+2. Execute write command
+3. Execute method (using Read command of device SDK)
 
-## Prerequisite
+## Prerequisites
 
 - Edgex-go: core data, core command, core metadata
 - OPCUA Server
 
 ## Predefined configuration
 
-### Pre-define Devices
+### Pre-defined Devices
 
 Define devices for device-sdk to auto upload device profile and create device instance. Please modify `devices.toml` file found under the `./cmd/res/devices` folder
 
@@ -34,7 +33,7 @@ Define devices for device-sdk to auto upload device profile and create device in
           Endpoint = "opc.tcp://node-red:55880/OPCUA/SimulationServer"
 ```
 
-### Subscribe configuration
+### Configuration
 
 Modify `configuration.toml` file found under the `./cmd/res` folder if needed
 
@@ -46,20 +45,25 @@ Modify `configuration.toml` file found under the `./cmd/res` folder if needed
   Mode = "None"                     # Security mode: None, Sign, SignAndEncrypt. Default: auto
   CertFile = ""                     # Path to cert.pem. Required for security mode/policy != None
   KeyFile = ""                      # Path to private key.pem. Required for security mode/policy != None
-  NodeID = "ns=5;s=Counter1"        # Node id to subscribe to
 ```
 
 ## Devic Profile
 
 A Device Profile can be thought of as a template of a type or classification of a Device.
 
-Write a device profile for your own devices; define deviceResources and deviceCommands. Please refer to `cmd/res/profiles/OpcuaServer.yaml`
+Write a device profile for your own devices; define `deviceResources` and `deviceCommands`. Please refer to `cmd/res/profiles/OpcuaServer.yaml`
 
 ## Installation and Execution
 
 ```bash
 make build
 make run
+```
+
+## Build a Container Image
+
+```bash
+make docker
 ```
 
 ## Reference

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository is a Go-based EdgeX Foundry Device Service which uses OPC-UA pro
 1. Subscribe data from OPCUA endpoint (TBD)
 2. Execute read command
 3. Execute write command
+4. Execute method (using Read command of device SDK)
 
 ## Prerequisite
 
@@ -50,11 +51,9 @@ Modify `configuration.toml` file found under the `./cmd/res` folder if needed
 
 ## Devic Profile
 
-A Device Profile can be thought of as a template of a type or classification of Device.
+A Device Profile can be thought of as a template of a type or classification of a Device.
 
-Write device profile for your own devices, define deviceResources, deviceCommands and coreCommands. Please refer to `cmd/res/profiles/OpcuaServer.yaml`
-
-Tips: name in deviceResources should consistent with OPCUA nodeid
+Write a device profile for your own devices; define deviceResources and deviceCommands. Please refer to `cmd/res/profiles/OpcuaServer.yaml`
 
 ## Installation and Execution
 

--- a/cmd/res/profiles/OpcuaServer.yaml
+++ b/cmd/res/profiles/OpcuaServer.yaml
@@ -29,6 +29,15 @@ deviceResources:
       maximum: "100.00"
     attributes:
       { namespace: "5", symbol: "Random1" }
+  -
+    name: "SetDefaultsMethod"
+    description: "Set all variables to their default values"
+    properties:
+      valueType: "String"
+      readWrite: "R"
+    attributes:
+      { namespace: "2", method: "Defaults", object: "", isMethod: true }
+
 
 deviceCommands:
   -
@@ -43,3 +52,9 @@ deviceCommands:
     readWrite: "R"
     resourceOperations:
       - { deviceResource: "Random1", defaultValue: "0.00" }
+  -
+    name: "SetDefaults"
+    isHidden: false
+    readWrite: "R"
+    resourceOperations:
+      - { deviceResource: "SetDefaultsMethod" }

--- a/cmd/res/profiles/OpcuaServer.yaml
+++ b/cmd/res/profiles/OpcuaServer.yaml
@@ -36,7 +36,21 @@ deviceResources:
       valueType: "String"
       readWrite: "R"
     attributes:
-      { namespace: "2", method: "Defaults", object: "", isMethod: true }
+      { namespace: "5", method: "Defaults", object: "", isMethod: true }
+  -
+    name: "AddNodeMethod"
+    description: "Add a Node to the OPCUA Server"
+    properties:
+      valueType: "String"
+      readWrite: "R"
+    attributes:
+      {
+        namespace: "5",
+        method: "NewNode",
+        object: "",
+        isMethod: true,
+        inputMap: [ "MyNewNode", "NewNode0", "int32" ],
+      }
 
 
 deviceCommands:
@@ -58,3 +72,9 @@ deviceCommands:
     readWrite: "R"
     resourceOperations:
       - { deviceResource: "SetDefaultsMethod" }
+  -
+    name: "AddNode"
+    isHidden: false
+    readWrite: "R"
+    resourceOperations:
+      - { deviceResource: "AddNodeMethod" }

--- a/cmd/res/profiles/OpcuaServer.yaml
+++ b/cmd/res/profiles/OpcuaServer.yaml
@@ -36,7 +36,7 @@ deviceResources:
       valueType: "String"
       readWrite: "R"
     attributes:
-      { namespace: "5", method: "Defaults", object: "", isMethod: true }
+      { namespace: "5", method: "Defaults", object: "" }
   -
     name: "AddNodeMethod"
     description: "Add a Node to the OPCUA Server"
@@ -48,7 +48,6 @@ deviceResources:
         namespace: "5",
         method: "NewNode",
         object: "",
-        isMethod: true,
         inputMap: [ "MyNewNode", "NewNode0", "int32" ],
       }
 

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -20,4 +20,8 @@ const (
 	NAMESPACE = "namespace"
 	// SYMBOL attribute
 	SYMBOL = "symbol"
+	// OBJECT attribute
+	OBJECT = "object"
+	// METHOD attribute
+	METHOD = "method"
 )

--- a/internal/driver/constants.go
+++ b/internal/driver/constants.go
@@ -24,4 +24,6 @@ const (
 	OBJECT = "object"
 	// METHOD attribute
 	METHOD = "method"
+	// INPUTMAP attribute
+	INPUTMAP = "inputMap"
 )

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -142,7 +142,7 @@ func (d *Driver) handleReadCommandRequest(deviceClient *opcua.Client, req sdkMod
 		result, err = makeMethodCall(deviceClient, req)
 		d.Logger.Infof("Method command finished: %v", result)
 	} else {
-		nodeID, err := buildNodeID(req.Attributes)
+		nodeID, err := buildNodeID(req.Attributes, SYMBOL)
 		if err != nil {
 			return result, fmt.Errorf("Driver.handleReadCommands: %v", err)
 		}
@@ -184,7 +184,7 @@ func makeReadRequest(deviceClient *opcua.Client, req sdkModel.CommandRequest, id
 func makeMethodCall(deviceClient *opcua.Client, req sdkModel.CommandRequest) (*sdkModel.CommandValue, error) {
 	var inputs []*ua.Variant
 
-	objectID, err := buildObjectID(req.Attributes)
+	objectID, err := buildNodeID(req.Attributes, OBJECT)
 	if err != nil {
 		return nil, fmt.Errorf("Driver.handleReadCommands: %v", err)
 	}
@@ -193,7 +193,7 @@ func makeMethodCall(deviceClient *opcua.Client, req sdkModel.CommandRequest) (*s
 		return nil, fmt.Errorf("Driver.handleReadCommands: %v", err)
 	}
 
-	methodID, err := buildMethodID(req.Attributes)
+	methodID, err := buildNodeID(req.Attributes, METHOD)
 	if err != nil {
 		return nil, fmt.Errorf("Driver.handleReadCommands: %v", err)
 	}
@@ -271,7 +271,7 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 
 func (d *Driver) handleWriteCommandRequest(deviceClient *opcua.Client, req sdkModel.CommandRequest,
 	param *sdkModel.CommandValue) error {
-	nodeID, err := buildNodeID(req.Attributes)
+	nodeID, err := buildNodeID(req.Attributes, SYMBOL)
 	if err != nil {
 		return fmt.Errorf("Driver.handleWriteCommands: %v", err)
 	}
@@ -323,37 +323,15 @@ func (d *Driver) Stop(force bool) error {
 	return nil
 }
 
-func buildNodeID(attrs map[string]interface{}) (string, error) {
+func buildNodeID(attrs map[string]interface{}, sKey string) (string, error) {
 	if _, ok := attrs[NAMESPACE]; !ok {
 		return "", fmt.Errorf("Attribute %s does not exist", NAMESPACE)
 	}
-	if _, ok := attrs[SYMBOL]; !ok {
-		return "", fmt.Errorf("Attribute %s does not exist", SYMBOL)
+	if _, ok := attrs[sKey]; !ok {
+		return "", fmt.Errorf("Attribute %s does not exist", sKey)
 	}
 
-	return fmt.Sprintf("ns=%s;s=%s", attrs[NAMESPACE].(string), attrs[SYMBOL].(string)), nil
-}
-
-func buildObjectID(attrs map[string]interface{}) (string, error) {
-	if _, ok := attrs[NAMESPACE]; !ok {
-		return "", fmt.Errorf("Attribute %s does not exist", NAMESPACE)
-	}
-	if _, ok := attrs[OBJECT]; !ok {
-		return "", fmt.Errorf("Attribute %s does not exist", OBJECT)
-	}
-
-	return fmt.Sprintf("ns=%s;s=%s", attrs[NAMESPACE].(string), attrs[OBJECT].(string)), nil
-}
-
-func buildMethodID(attrs map[string]interface{}) (string, error) {
-	if _, ok := attrs[NAMESPACE]; !ok {
-		return "", fmt.Errorf("Attribute %s does not exist", NAMESPACE)
-	}
-	if _, ok := attrs[METHOD]; !ok {
-		return "", fmt.Errorf("Attribute %s does not exist", METHOD)
-	}
-
-	return fmt.Sprintf("ns=%s;s=%s", attrs[NAMESPACE].(string), attrs[METHOD].(string)), nil
+	return fmt.Sprintf("ns=%s;s=%s", attrs[NAMESPACE].(string), attrs[sKey].(string)), nil
 }
 
 func newResult(req sdkModel.CommandRequest, reading interface{}) (*sdkModel.CommandValue, error) {


### PR DESCRIPTION
Allows defining `deviceResources` and `deviceCommands` to call methods defined in OPCUA. 

- Each method call is a read request
- The `valueType` property should be the data type returned by the method
- The `inputMap` attribute is of type `[]interface{}`
- If the `method` attribute is present, the command will be treated as a method call